### PR TITLE
Adding course routes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: npx sequelize-cli db:migrate

--- a/index.js
+++ b/index.js
@@ -1,7 +1,19 @@
 const express = require('express')
 const app = express()
-const port = 3000
+// Environment decides port when in Heroku
+const port = process.env.PORT || 4000
+const courseRoutes = require('./routes/courseRoutes')
+
+// Middlewares for testing front end
+const jsonParser = express.json();
+const cors = require("cors");
+
+app.use(jsonParser);
+app.use(cors());
 
 app.get('/', (req, res) => res.send('Hello World!'))
 
 app.listen(port, () => console.log(`Example app listening at http://localhost:${port}`))
+
+
+app.use('/course', courseRoutes)

--- a/package-lock.json
+++ b/package-lock.json
@@ -407,6 +407,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -1235,6 +1244,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,23 @@
 {
-  "name": "eacademy-backend-node",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
-  "license": "ISC",
-  "devDependencies": {
-    "nodemon": "^2.0.4"
-  },
-  "dependencies": {
-    "cors": "^2.8.5",
-    "dotenv": "^8.2.0",
-    "express": "^4.17.1",
-    "pg": "^8.3.0",
-    "sequelize": "^6.3.3",
-    "sequelize-cli": "^6.2.0"
-  }
+	"name": "eacademy-backend-node",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"start": "node index.js",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"author": "",
+	"license": "ISC",
+	"devDependencies": {
+		"nodemon": "^2.0.4"
+	},
+	"dependencies": {
+		"cors": "^2.8.5",
+		"dotenv": "^8.2.0",
+		"express": "^4.17.1",
+		"pg": "^8.3.0",
+		"sequelize": "^6.3.3",
+		"sequelize-cli": "^6.2.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "nodemon": "^2.0.4"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "pg": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"main": "index.js",
 	"scripts": {
 		"start": "node index.js",
+		"develop": "nodemon index.js",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "",

--- a/routes/courseRoutes.js
+++ b/routes/courseRoutes.js
@@ -1,0 +1,29 @@
+const express = require('express')
+const router = express.Router()
+const Course = require('../models').course
+const Lesson = require('../models').lesson
+
+
+router.get('/', async function (req, res, next) {
+	try {
+		const allCourses = await Course.findAndCountAll({ include: [Lesson] })
+		res.send(allCourses)
+	} catch (e) {
+		console.log(e)
+	}
+})
+
+router.get('/:id', async function (req, res, next) {
+
+	const id = req.params.id
+	console.log(`We got a request for user id ${id}`)
+	try {
+		const selectedCourse = await Course.findByPk(id, { include: [Lesson], plain: true })
+		res.send(selectedCourse)
+	} catch (e) {
+		console.log(e)
+	}
+})
+
+
+module.exports = router


### PR DESCRIPTION
This pull request makes the backend workable on Heroku for basic MVP functionalities.

- Will provide get endpoint for querying all courses via /course
- Will provide get endpoint for querying course and lesson details via /course/id

And will compile on Heroku because.

- Includes procfile which makes Heroku happy to mount the database.
- Includes npm scripts so heroku knows what to do when deploying.